### PR TITLE
add case-insensitive and support for multiple arguments

### DIFF
--- a/zjumper_ranger.py
+++ b/zjumper_ranger.py
@@ -15,11 +15,15 @@ class z(Command):
             flists = fobj.readlines()
 
         # user given directory
-        req = self.args[1]
+        req = self.args
         directories = []
         for i in flists:
-            if req.lower() in i.lower():
-                directories.append(i.split("|")[0])
+            for j in req[1:]:
+                if j.lower() in i.lower():
+                    if j == req[-1]:
+                        directories.append(i.split("|")[0])
+                else:
+                    break
 
         try:
             #  smallest(length) directory will be the directory required

--- a/zjumper_ranger.py
+++ b/zjumper_ranger.py
@@ -18,7 +18,7 @@ class z(Command):
         req = self.args[1]
         directories = []
         for i in flists:
-            if req in i:
+            if req.lower() in i.lower():
                 directories.append(i.split("|")[0])
 
         try:


### PR DESCRIPTION
Hello, good plugin to make zjumper work in ranger. But I meet some problem when I use it.

I used `z doc cs` to jump into `~/Documents/CS` in shell and it worked well. However when I use `:z doc cs` in ranger by this plugin, It can't work properly. So I modified some codes to make the plugin case-insensitive and support to multiple arguments to make it works just like z.sh in a shell.

Looking forward to your reply!